### PR TITLE
DOCKER_TLS_CERTDIR => DOCKER_CERT_PATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     expose:
       - '22'
     environment:
-      DOCKER_TLS_CERTDIR: '/certs'
+      DOCKER_CERT_PATH: '/certs/client'
       DOCKER_HOST: 'tcp://docker:2376'
       DOCKER_TLS_VERIFY: 1
       JENKINS_SLAVE_SSH_PUBKEY: 'ssh public key data here'


### PR DESCRIPTION
With the current version, my agent was not able to run docker commands. Neither using direct access (`docker exec`) nor inside a pipeline step inside Jenkins.

With this change, the agent has access to the docker daemon as initially designed.

(apply for Windows, not tested with other "fancy" OSs)

I think there was a confusion during the writing with multiple source of information, like https://github.com/docker-library/docker/blob/master/docker-entrypoint.sh#L43 or https://gitlab.com/gitlab-org/gitlab-foss/issues/64968 (and many other) as the base image is not a docker official image but a Jenkins image, based on openjdk (the scratch).

<details>

<summary>"proof"</summary>

![Screenshot_2019-11-20_135900_001](https://user-images.githubusercontent.com/2662497/69240998-0384e200-0b9e-11ea-83f2-829facb5f8b6.png)


![Screenshot_2019-11-20_140015_001](https://user-images.githubusercontent.com/2662497/69241022-14cdee80-0b9e-11ea-8acf-1bbaa50bdacf.png)


</details>